### PR TITLE
chore: auto assign PR requests to author

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,13 @@
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [X] Documentation update
- [ ] Refactoring
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.] -->
Auto-assign PRs to be the PR authors.

## Additional Information
<!-- [Any additional information that reviewers should be aware of.] --> 
@jfjeld15 @gareba Can auto-assign individuals to PR reviews too, but that requires us to switch this repository to an organization. I know it feels overkill, but would you be down? 
